### PR TITLE
Use slim-buster because wbe3 has a problem with alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
-FROM python:3.6-alpine
+FROM python:3.8-slim-buster
 LABEL maintainer="Keyko <root@keyko.io>"
 
 ARG VERSION
 
-RUN apk add --no-cache --update\
-    build-base \
-    gcc \
-    gettext\
-    gmp \
-    gmp-dev \
-    libffi-dev \
-    openssl-dev \
-    py-pip \
-    python3 \
-    python3-dev \
-  && pip install virtualenv
+RUN apt-get update \
+    && apt-get install gcc -y \
+    && apt-get clean
 
 COPY . /nevermined-gateway
 WORKDIR /nevermined-gateway


### PR DESCRIPTION
## Description

Update dockerfile to use `slim-buster` since web3 isn't building in alpine

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
