### PR TITLE
Support JWT with ethereum signature

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = False
 tag = False
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,7 +36,7 @@ jobs:
         git clone https://github.com/nevermined-io/tools nevermined-tools
         cd nevermined-tools
         rm -rf "${HOME}/.nevermined/nevermined-contracts/artifacts"
-        ./start_nevermined.sh --no-commons --no-gateway --ldap --latest --compute &
+        ./start_nevermined.sh --no-marketplace --no-gateway --ldap --latest --compute &
 
         # wait for the compute api to be online
         # the compute api is the last service to come online

--- a/nevermined_gateway/identity/jwk_utils.py
+++ b/nevermined_gateway/identity/jwk_utils.py
@@ -9,17 +9,18 @@ from authlib.jose.errors import DecodeError
 from authlib.jose.util import extract_segment
 from cryptography.hazmat.primitives import serialization
 import ecdsa
+import sha3
 
 from authlib.jose import JsonWebKey
 from eth_keys import keys
 
 
-def recover_public_keys_from_signature(signing_input, signature):
+def recover_public_keys_from_signature(signing_input, signature, hashfunc=hashlib.sha256):
     # use ecdsa library to recover public keys
     possible_keys =  ecdsa.VerifyingKey.from_public_key_recovery(
-        signature, signing_input, ecdsa.SECP256k1, hashfunc=hashlib.sha256
+        signature, signing_input, ecdsa.SECP256k1, hashfunc=hashfunc
     )
-    
+
     # convert to JWK
     jwks = []
     for public_key in possible_keys:
@@ -35,6 +36,12 @@ def recover_public_keys_from_assertion(assertion):
     return recover_public_keys_from_signature(signature_input, signature)
 
 
+def recover_public_keys_from_eth_assertion(assertion):
+    signature_input, signature = split_assertion(assertion)
+    eth_signature_input = ('\u0019Ethereum Signed Message:\n' + str(len(signature_input)) + signature_input.decode()).encode()
+    return recover_public_keys_from_signature(eth_signature_input, signature, hashfunc=sha3.keccak_256)
+
+
 def split_assertion(assertion):
     signature_input, signature_segment = assertion.rsplit(b".", 1)
     signature = extract_segment(signature_segment, DecodeError, "signature")
@@ -48,7 +55,7 @@ def public_key_bytes_to_jwk(public_key_bytes):
         "x": base64.urlsafe_b64encode(public_key_bytes[:32]),
         "y": base64.urlsafe_b64encode(public_key_bytes[32:])
     }
-    
+
     return JsonWebKey.import_key(jwk_json)
 
 
@@ -61,6 +68,6 @@ def jwk_to_eth_address(jwk):
     public_key = jwk.get_public_key()
     public_key_bytes = public_key.public_bytes(
         serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint)
-    
+
     # X962 format prepends the 0x04 byte to signal that this uncompressed
     return public_key_bytes_to_eth_address(public_key_bytes[1:])

--- a/nevermined_gateway/identity/oauth2/token.py
+++ b/nevermined_gateway/identity/oauth2/token.py
@@ -55,6 +55,15 @@ class NeverminedJWTBearerGrant(_NeverminedJWTBearerGrant):
         # and we can return any of them
         possible_public_keys = recover_public_keys_from_assertion(assertion)
 
+        # if signing with ethereum this recovery becomes the de-facto signature verification
+        # since we check if any of these keys match the issuer of the token.
+        #
+        # signing with ethereum differs from ES256K
+        #   - it adds a prefix to the message to sign
+        #   - it uses keccak_256 hash function instead of sha256
+        #
+        # we then return a public key that verifies the message so that
+        # authlib doesn't complain with a bad signature
         eths = payload.get("eths")
         if eths == "personal":
             possible_eths_keys = recover_public_keys_from_eth_assertion(assertion)

--- a/nevermined_gateway/routes.py
+++ b/nevermined_gateway/routes.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from authlib.jose.errors import BadSignatureError
 
 from common_utils_py.did import id_to_did, NEVERMINED_PREFIX
 from common_utils_py.did_resolver.did_resolver import DIDResolver
@@ -461,4 +462,9 @@ def execute_compute_job():
 
 @services.route('/oauth/token', methods=['POST'])
 def issue_token():
-    return authorization.create_token_response()
+    try:
+        return authorization.create_token_response()
+    except BadSignatureError as e:
+        msg = f"Bad Signature: {str(e)}"
+        logger.warning(msg)
+        return msg, 401

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/gateway',
-    version='0.5.0',
+    version='0.5.1',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('CHANGELOG.md') as history_file:
 install_requirements = [
     # Install squid-py and all its dependencies first
     'common-utils-py==0.4.3',
-    'contracts-lib-py==0.5.2',
+    'contracts-lib-py==0.5.4',
     'nevermined-secret-store==0.1.0',
     'Flask==1.1.2',
     'Flask-Cors==3.0.8',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('CHANGELOG.md') as history_file:
 # or pip install -e .
 install_requirements = [
     # Install squid-py and all its dependencies first
-    'common-utils-py==0.4.2',
+    'common-utils-py==0.4.3',
     'contracts-lib-py==0.5.2',
     'nevermined-secret-store==0.1.0',
     'Flask==1.1.2',
@@ -36,7 +36,8 @@ install_requirements = [
     'nevermined-authlib==0.1.0',
     'cryptography==3.2.1',
     'ecdsa==0.16.1',
-    'eth-keys==0.3.3'
+    'eth-keys==0.3.3',
+    "pysha3==1.0.2"
 ]
 
 # Required to run setup.py:


### PR DESCRIPTION
## Description

Depends on https://github.com/nevermined-io/common-utils-py/pull/18

This pr adds support for verifying signatures generated by ethereum (prefixed message with secp256k1 and keccak_256)

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
