### PR TITLE
Use pre-packaged artifacts by default

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -64,6 +64,7 @@ jobs:
         export RSA_PRIVKEY_FILE=tests/resources/data/rsa_priv_key.pem
         export RSA_PUBKEY_FILE=tests/resources/data/rsa_pub_key.pem
         export AUTHLIB_INSECURE_TRANSPORT=true
+        export INFURA_TOKEN=${{ secrets.INFURA_TOKEN }}
 
         pip install pytest
         pytest -v

--- a/nevermined_gateway/run.py
+++ b/nevermined_gateway/run.py
@@ -1,4 +1,3 @@
-import configparser
 import logging
 import sys
 
@@ -16,8 +15,6 @@ from nevermined_gateway import version
 from nevermined_gateway.util import keeper_instance, get_provider_account, get_provider_key_file, \
     get_provider_password, get_rsa_public_key_file
 
-config = Config(filename=app.config['CONFIG_FILE'])
-gateway_url = config.get(ConfigSections.RESOURCES, 'gateway.url')
 
 requests_session = get_requests_session()
 logger = logging.getLogger(__name__)
@@ -40,6 +37,7 @@ def get_external_contracts():
 
 @app.route("/")
 def root_info():
+    config = Config(filename=app.config['CONFIG_FILE'])
     keeper = keeper_instance()
     info = {
         'software': Metadata.TITLE,
@@ -71,16 +69,20 @@ def spec():
 
 
 # Call factory function to create our blueprint
-swaggerui_blueprint = get_swaggerui_blueprint(
-    BaseURLs.SWAGGER_URL,
-    gateway_url + '/spec',
-    config={  # Swagger UI config overrides
-        'app_name': "Test application"
-    },
-    )
+def get_swagger_blueprint():
+    config = Config(filename=app.config['CONFIG_FILE'])
+    gateway_url = config.get(ConfigSections.RESOURCES, 'gateway.url')
+
+    return get_swaggerui_blueprint(
+        BaseURLs.SWAGGER_URL,
+        gateway_url + '/spec',
+        config={  # Swagger UI config overrides
+            'app_name': "Test application"
+        },
+        )
 
 # Register blueprint at URL
-app.register_blueprint(swaggerui_blueprint, url_prefix=BaseURLs.SWAGGER_URL)
+app.register_blueprint(get_swagger_blueprint(), url_prefix=BaseURLs.SWAGGER_URL)
 app.register_blueprint(services, url_prefix=BaseURLs.ASSETS_URL)
 
 if __name__ == '__main__':

--- a/nevermined_gateway/util.py
+++ b/nevermined_gateway/util.py
@@ -3,7 +3,6 @@ import json
 import logging
 import mimetypes
 import os
-import site
 import uuid
 from datetime import datetime
 from os import getenv
@@ -18,6 +17,7 @@ from eth_utils import remove_0x_prefix
 from flask import Response
 from metadata_driver_interface.driver_interface import DriverInterface
 from secret_store_client.client import Client as SecretStore
+from nevermined_contracts import get_artifacts_path
 
 from nevermined_gateway.config import Config
 from nevermined_gateway.constants import ConditionState
@@ -222,14 +222,10 @@ def get_env_property(env_variable, property_name):
 
 
 def get_keeper_path(config):
-    path = config.keeper_path
-    if not os.path.exists(path):
-        if os.getenv('VIRTUAL_ENV'):
-            path = os.path.join(os.getenv('VIRTUAL_ENV'), 'artifacts')
-        else:
-            path = os.path.join(site.PREFIXES[0], 'artifacts')
+    if config.keeper_path and config.keeper_path != '':
+        return config.keeper_path
 
-    return path
+    return get_artifacts_path()
 
 
 def keeper_instance():

--- a/nevermined_gateway/version.py
+++ b/nevermined_gateway/version.py
@@ -2,4 +2,4 @@
 
 Follows option 3 of https://packaging.python.org/guides/single-sourcing-package-version/
 """
-__version__ = '0.8.7'
+__version__ = '0.8.8'

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ with open("nevermined_gateway/version.py") as version_file:
 # or pip install -e .
 install_requirements = [
     # Install squid-py and all its dependencies first
-    'common-utils-py==0.7.3',
-    'contracts-lib-py==0.7.7',
+    'common-utils-py==0.7.5',
+    'contracts-lib-py==0.7.11',
     'nevermined-secret-store==0.1.1',
     'Flask==1.1.2',
     'Flask-Cors==3.0.9',

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -9,6 +9,7 @@ from nevermined_gateway.config import Config
 
 INFURA_TOKEN = os.environ.get("INFURA_TOKEN")
 
+pytestmark = pytest.mark.skip()
 
 @pytest.mark.parametrize("keeper_url,network_name", [
     [f"https://mainnet.infura.io/v3/{INFURA_TOKEN}", "mainnet"],

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -18,7 +18,7 @@ INFURA_TOKEN = os.environ.get("INFURA_TOKEN")
     ("https://alfajores-forno.celo-testnet.org", "celo-alfajores"),
     ("https://baklava-forno.celo-testnet.org", "celo-baklava")
 ])
-def test_artifact(keeper_url, network_name, monkeypatch):
+def test_artifact(keeper_url, network_name):
     options = {
         "nevermined-contracts": {
             "keeper.url": keeper_url,

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+from unittest import mock
+
+from contracts_lib_py.web3_provider import Web3Provider
+import pytest
+
+from nevermined_gateway.config import Config
+
+INFURA_TOKEN = os.environ.get("INFURA_TOKEN")
+
+
+@pytest.mark.parametrize("keeper_url,network_name", [
+    [f"https://mainnet.infura.io/v3/{INFURA_TOKEN}", "mainnet"],
+    [f"https://rinkeby.infura.io/v3/{INFURA_TOKEN}", "rinkeby"],
+    ("http://localhost:8545", "spree"),
+    ("https://matic-mumbai.chainstacklabs.com", "mumbai"),
+    ("https://alfajores-forno.celo-testnet.org", "celo-alfajores"),
+    ("https://baklava-forno.celo-testnet.org", "celo-baklava")
+])
+def test_artifact(keeper_url, network_name, monkeypatch):
+    options = {
+        "nevermined-contracts": {
+            "keeper.url": keeper_url,
+            "keeper.path": ""
+        },
+        "resources": {
+            "gateway.url": "http://localhost:8030"
+        }
+    }
+    config = Config(options_dict=options)
+    config_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    config.write(config_file)
+    config_file.flush()
+    config_file_name = config_file.name
+    config_file.close()
+
+    with mock.patch.dict(os.environ, {'CONFIG_FILE': config_file_name}):
+
+        from nevermined_gateway.run import app
+        from nevermined_gateway.util import setup_keeper
+
+
+        app.config['CONFIG_FILE'] = config_file_name
+        Web3Provider._web3 = None
+        setup_keeper(app.config['CONFIG_FILE'])
+        client = app.test_client()
+
+        response = client.get('/')
+        assert response.json['network'] == network_name
+        assert response.json['keeper-url'] == keeper_url


### PR DESCRIPTION
## Description

- Use the pre packaged artifacts by default
- Override the use of the pre-packaged artifacts by setting `keeper.path`

@jcortejoso I made it so that it will also use the pre-packaged artifacts if `keeper.path=''` so to make it easier for deployments

## Is this PR related with an open issue?

Relates to https://github.com/nevermined-io/internal/issues/158
Relates to https://github.com/nevermined-io/internal/issues/153

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
