### PR TITLE
Handle the not enough balance case when calling nft-transfer

### DIFF
--- a/docs/nft_transfer.yml
+++ b/docs/nft_transfer.yml
@@ -42,5 +42,7 @@ responses:
     description: The nftReceiver has not locked the payment.
   405:
     description: The nftHolder has not approved the gateway to perform the NFT transfer.
+  406:
+    description: The nftHolder does not have enough nfts to transfer.
   500:
     description: Error

--- a/nevermined_gateway/routes.py
+++ b/nevermined_gateway/routes.py
@@ -18,7 +18,7 @@ from secret_store_client.client import RPCError
 from web3 import Web3
 
 from nevermined_gateway import constants
-from nevermined_gateway.conditions import fulfill_escrow_payment_condition, fulfill_for_delegate_nft_transfer_condition
+from nevermined_gateway.conditions import fulfill_escrow_payment_condition, fulfill_for_delegate_nft_transfer_condition, is_nft_holder
 from nevermined_gateway.config import upload_backends
 from nevermined_gateway.identity.oauth2.authorization_server import create_authorization_server
 from nevermined_gateway.identity.oauth2.resource_server import create_resource_server
@@ -392,6 +392,11 @@ def nft_transfer():
         nft_transfer_condition_id,
         escrow_payment_condition_id
     ) = agreement.condition_ids
+
+    if not is_nft_holder(keeper, agreement.did, nft_amount, nft_holder_address):
+        msg = f'Holder {nft_holder_address} does not have enough NFTs to transfer'
+        logger.warning(msg)
+        return msg, 406
 
     if not is_lock_payment_condition_fulfilled(lock_payment_condition_id, keeper):
         msg = f'lockPayment condition for agreement_id={agreement_id} is not fulfilled'

--- a/nevermined_gateway/version.py
+++ b/nevermined_gateway/version.py
@@ -3,4 +3,4 @@
 Follows option 3 of https://packaging.python.org/guides/single-sourcing-package-version/
 """
 
-__version__ = '0.11.0'
+__version__ = '0.11.1'


### PR DESCRIPTION


## Description

- The `/nft-transfer` endpoint now handles the case where the nftHolder does not enough balance to perform the transfer
- bumped version to 0.11.1

## Is this PR related with an open issue?

Resolves https://github.com/nevermined-io/autonomies/issues/284

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
